### PR TITLE
Added operational attributes to query

### DIFF
--- a/matrix_corporal_policy_ldap/__init__.py
+++ b/matrix_corporal_policy_ldap/__init__.py
@@ -384,7 +384,7 @@ class PolicyConfig:
         searchparams = {
             "search_base": self.ldap["user_base"],
             "search_filter": query,
-            "attributes": ["*"],
+            "attributes": ["+","*"],
             "search_scope": self.ldap["scope"],
             "paged_size": 500,
         }


### PR DESCRIPTION
When running with OpenLDAP the script complained about not having access to the attribute `memberOf`, even though I configured the server to calculate this attribute. The problem was, that `*` does not generate all operational attributes. Changing it to `["+", "*"]` also computes the necessary operational attributes (in this case `memberOf`)